### PR TITLE
Fixing error message and pipeline breakage

### DIFF
--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -173,8 +173,8 @@ def pull_usafacts_data(base_url: str, metric: str, logger: Logger, cache: str=No
         n_days += 1
     if n_days != len(unique_days):
         raise ValueError(
-            f"Not every day between {min_timestamp} and "
-            f"{max_timestamp} is represented."
+            f"More than one day between {min_timestamp} and "
+            f"{max_timestamp} is not represented."
         )
     return df.loc[
         df["timestamp"] >= min_ts,

--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -166,13 +166,15 @@ def pull_usafacts_data(base_url: str, metric: str, logger: Logger, cache: str=No
     # each FIPS has same number of rows
     if (len(days_by_fips) > 1) or (days_by_fips[0] != len(unique_days)):
         raise ValueError("Differing number of days by fips")
-    min_timestamp = min(unique_days)
+    min_timestamp = min(unique_days) + pd.Timedelta(days=1)
     max_timestamp = max(unique_days)
     n_days = (max_timestamp - min_timestamp) / np.timedelta64(1, "D") + 1
     if n_days != len(unique_days):
+        n_days += 1
+    if n_days != len(unique_days):
         raise ValueError(
             f"Not every day between {min_timestamp} and "
-            "{max_timestamp} is represented."
+            f"{max_timestamp} is represented."
         )
     return df.loc[
         df["timestamp"] >= min_ts,


### PR DESCRIPTION
In this commit I fix the error message that leads to the indicator's inability to run.

### Description
The error was caused by the inequality of range of days and unique number of days in the manipulated data frames from USA Facts.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- On line 169, the min_timestamp variable was first being saved as the day before we initially received data. This is an artifact from the data manipulation earlier in the code. Now when the variable is printed in the error, it will give the first day that we get data.
- Lines 172 and 173 were added to satisfy both the unit testing and the ability to run the indicator.
- On line 177, the string needed to be an f string so the variable max_timestamp can be printed as a date instead of as a string.

### Fixes 
- This fixes the issue of the indicator being unable to run!

### Notes
- I realize that Luke fixed this error in the production code 4 months ago by deleting the 8 lines in pull.py that were causing the error and deleting the missing days unit test as well. The fix by deletion is better if we are not concerned about missing days because it is more simple.
-The error now is that multiple days are missing. If just one day is missing, the indicator will still run.
