### PR TITLE
Update pull.py

### DIFF
--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -172,7 +172,7 @@ def pull_usafacts_data(base_url: str, metric: str, logger: Logger, cache: str=No
     
     # Make exception for July 1st 2022 which is a missing day
     if pd.Timestamp('2022-06-30 00:00:00') and pd.Timestamp('2022-07-02 00:00:00') in unique_days:
-    n_days -= 1
+        n_days -= 1
             
     # Loop to discover and report missing days
     if n_days != len(unique_days):


### PR DESCRIPTION
Found missing day, made exception, improved error message

### Description
The issue arose from an inability to run the USA facts indicator. The first step to solving the broken pipeline was to fix the error message by creating a while loop to learn which day was missing and print it in the error message. Then an exception was made to go around the missing day but only when it is present in the time series that the code is currently running. This PR satisfies 

### Changelog
- Line 179-182 provides a loop to find the number of missing days and print them in an improved error.
- Line 174 and 175 are an exception for July 1, 2022 - a missing day. This day was found using the improved error.

### Fixes 
- Fixed indicator pipeline breakage.
